### PR TITLE
Fix MessageResponse import and Streamdown props forwarding

### DIFF
--- a/src/lib/components/ai-elements/message/response/MessageResponse.svelte
+++ b/src/lib/components/ai-elements/message/response/MessageResponse.svelte
@@ -9,10 +9,10 @@
 	import { mode } from 'mode-watcher';
 	import githubDarkDefault from '@shikijs/themes/github-dark-default';
 	import githubLightDefault from '@shikijs/themes/github-light-default';
-	import { cn } from '$lib/utils';
+	import { cn } from '$lib/utils/utils';
 	type Props = StreamdownProps;
 
-	let { content, class: className, components, ...restProps }: Props = $props();
+	let { content, class: className, ...restProps }: Props = $props();
 	let currentTheme = $derived(
 		mode.current === 'dark' ? 'github-dark-default' : 'github-light-default'
 	);

--- a/src/lib/components/ai-elements/message/response/message-response.svelte
+++ b/src/lib/components/ai-elements/message/response/message-response.svelte
@@ -12,7 +12,7 @@
 	import { cn } from "$lib/utils";
 	type Props = StreamdownProps;
 
-	let { content, class: className, components, ...rest }: Props = $props();
+	let { content, class: className, ...rest }: Props = $props();
 	let currentTheme = $derived(
 		mode.current === "dark" ? "github-dark-default" : "github-light-default"
 	);


### PR DESCRIPTION
related pr: #119

1. Fix broken `cn` import path in `MessageResponse`
2. Ensure `components` and other Streamdown props are forwarded to `Streamdown`