### PR TITLE
Fix DOM issue in ActionMenuTrigger

### DIFF
--- a/src/lib/components/ai-elements/prompt-input/action-menu/action-menu-trigger.svelte
+++ b/src/lib/components/ai-elements/prompt-input/action-menu/action-menu-trigger.svelte
@@ -8,15 +8,17 @@
 		children?: import("svelte").Snippet;
 	}
 
-	let { class: className, children, ...props }: Props = $props();
+	let { class: className, children, ...restProps }: Props = $props();
 </script>
 
 <DropdownMenu.Trigger>
-	<Button class={className} {...props}>
-		{#if children}
-			{@render children()}
-		{:else}
-			<PlusIcon class="size-4" />
-		{/if}
-	</Button>
+	{#snippet child({ props })}
+		<Button class={className} {...props} {...restProps}>
+			{#if children}
+				{@render children()}
+			{:else}
+				<PlusIcon class="size-4" />
+			{/if}
+		</Button>
+	{/snippet}
 </DropdownMenu.Trigger>


### PR DESCRIPTION
Currently the `ActionMenuTrigger` component renders a `<button>` in `<button>`:

```html
<button
  data-slot="dropdown-menu-trigger"
  id="bits-c4"
  aria-haspopup="menu"
  aria-expanded="false"
  data-state="closed"
  data-dropdown-menu-trigger=""
  type="button"
>
  <button
    data-slot="button"
    class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&amp;_svg:not([class*='size-'])]:size-4 group/button inline-flex items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-9 shrink-0 gap-1.5 rounded-lg text-muted-foreground"
    type="button"
  >
    [...]
  </button>
</button>
```

This triggers an error, for example in SvelteKit:

```
node_invalid_placement_ssr: `<button>` (src/lib/components/ui/button/button.svelte:79:1) cannot be a child of `<button>` (/home/cbenz/[...]/node_modules/.pnpm/bits-ui@2.18.1_@internationalized+date@3.12.2_@sveltejs+kit@2.64.0_@opentelemetry+api@1_2e8b7f5b8db4b166b45cbd6dd6a662cb/node_modules/bits-ui/dist/bits/utilities/floating-layer/components/floating-layer-anchor.svelte:36:2)

This can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.
```

I used the `child` snippet to avoid this DOM issue.
